### PR TITLE
Patch-1: Correção da chamada da função replace na função overdisp

### DIFF
--- a/statstests/pytests/test.py
+++ b/statstests/pytests/test.py
@@ -1,9 +1,10 @@
+import pytest
+import pandas as pd
+
 def test_replace():
     """
-        Teste para validar alteração
-    """
-    import pytest
-    import pandas as pd
+        Test to validate changes
+    """    
     df = pd.DataFrame({'[col.1]': [1, 2], '[col.2]': [3, 4]})
     df.columns = df.columns.str.replace('\[', '', regex=True)
     df.columns = df.columns.str.replace('\.', '_', regex=True)

--- a/statstests/pytests/test.py
+++ b/statstests/pytests/test.py
@@ -1,0 +1,13 @@
+def test_replace():
+    """
+        Teste para validar alteração
+    """
+    import pytest
+    import pandas as pd
+    df = pd.DataFrame({'[col.1]': [1, 2], '[col.2]': [3, 4]})
+    df.columns = df.columns.str.replace('\[', '', regex=True)
+    df.columns = df.columns.str.replace('\.', '_', regex=True)
+    df.columns = df.columns.str.replace('\]', '', regex=True)
+
+    df_expected = pd.DataFrame({'col_1': [1, 2], 'col_2': [3, 4]})    
+    assert df.columns.all() == df_expected.columns.all()

--- a/statstests/tests.py
+++ b/statstests/tests.py
@@ -123,9 +123,9 @@ def overdisp(model, data):
                     model.model.data.orig_exog], axis=1)
 
     # adjust column names with special characters from categorical columns
-    df.columns = df.columns.str.replace('[', '', regex=True)
-    df.columns = df.columns.str.replace('.', '_', regex=True)
-    df.columns = df.columns.str.replace(']', '', regex=True)
+    df.columns = df.columns.str.replace('\[', '', regex=True)
+    df.columns = df.columns.str.replace('\.', '_', regex=True)
+    df.columns = df.columns.str.replace('\]', '', regex=True)
 
     # adjust formula with special characters from categorical columns
     formula = formula.replace("[", "")


### PR DESCRIPTION
Ao utilizar a versão 2.1.3 do pandas, ocorre erros de execução (linhas 126 e 128):

re.error: unterminated character set at position 0

E erros de comportamento inesperado (linha 127), onde ao usar replace "." com regex=True toda cadeia de caracteres é substituída por "_".


Gostaria que avaliassem a alteração e caso seja benéfica, aceitem este PR.

Muito obrigado.